### PR TITLE
# A small modification to ensure a model run over 2 consecutive years

### DIFF
--- a/R/rye_biomV1.R
+++ b/R/rye_biomV1.R
@@ -25,6 +25,9 @@ rye_biomV1 <- function(param, weather, sdate, tdate){
   TTM= param["TTM"]
   TTL= param["TTL"]
 
+  sdate= lubridate::yday(as.character(sdate))      #Transform date to julian days & ensure simulation runs for 2 consecutive years
+  tdate= lubridate::yday(as.character(tdate)) + 365
+
   TT= rep(NA, tdate)                                #Define state variables
   B= rep(NA, tdate)
   LAI= rep(NA, tdate)
@@ -56,7 +59,6 @@ rye_biomV1 <- function(param, weather, sdate, tdate){
                      LAI= LAI[sdate:tdate],
                      B= B[sdate:tdate]))
 }
-
 
 
 


### PR DESCRIPTION
I have included a small modification to ensure the model runs over …2 consecutive years. This change entailed inputting the seeding and termination dates (i.e. the sdate and tdate arguments) as characters. 
In the function body, the package "lubridate", which I use to work date types, has been called as an import. The function yday(...) returns the calendar day as needed. The variable tdate, therefore, refers to termination date in year 2 (i.e. tdate= yday(...) + 365.
The state variables (thermal time, LAI, and Biomass) are updated daily, starting at sdate in year 1, and finish at tdate in year 2.
As for now an array with parameter values, a weather dataset processed with weather_rb, and indication of when the cover crop is planted and terminated, are sufficient to produce biomass accumulation over 2 years.